### PR TITLE
fix: release job image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   deploy:
     name: deploy
     environment: main
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## What

Updates release job image to one that works with AWS CLI without issue (ref: [AWS CLI calls broken during change from 2.169.1 to 2.262.1](https://github.com/aws/aws-cli/issues/5262))