### PR TITLE
fix: deploy depends on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         run: npx semantic-release
   deploy:
     name: deploy
+    needs: release
     environment: main
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
## What

Fixes `deploy` job to depend on `release` first as it has CI baked in to ensure quality after merge into `main`.